### PR TITLE
Handle the zero-length packet when the first transfer exactly matches the transaction size

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -996,7 +996,8 @@ impl<'a> PtpCamera<'a> {
         payload.extend_from_slice(&buf[PTP_CONTAINER_INFO_SIZE..]);
 
         // response didn't fit into our original buf? read the rest
-        if payload.len() < cinfo.payload_len {
+        // or if our original read were satisfied exactly, so there is still a ZLP to read
+        if payload.len() < cinfo.payload_len || buf.len() == unintialized_buf.len() {
             unsafe {
                 let p = payload.as_mut_ptr().offset(payload.len() as isize);
                 let pslice = slice::from_raw_parts_mut(p, payload.capacity() - payload.len());


### PR DESCRIPTION
Verified by adding

```
        if cinfo.payload_len == unintialized_buf.len() - PTP_CONTAINER_INFO_SIZE {
            warn!("handled 8192-byte packet");
        }
```

and reproducing the issue
