### PR TITLE
Better handle transactions with large payloads written to the device

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -830,28 +830,6 @@ impl PtpContainerInfo {
     }
 }
 
-fn ptp_gen_message(w: &mut Write,
-                   kind: PtpContainerType,
-                   code: CommandCode,
-                   tid: u32,
-                   payload: &[u8]) {
-    let len: u32 = 12 + payload.len() as u32;
-
-    w.write_u32::<LittleEndian>(len).ok();
-    w.write_u16::<LittleEndian>(kind as u16).ok();
-    w.write_u16::<LittleEndian>(code).ok();
-    w.write_u32::<LittleEndian>(tid).ok();
-    w.write_all(payload).ok();
-}
-
-fn ptp_gen_cmd_message(w: &mut Write, code: CommandCode, tid: u32, params: &[u32]) {
-    let mut payload = vec![];
-    for p in params {
-        payload.write_u32::<LittleEndian>(*p).ok();
-    }
-    ptp_gen_message(w, PtpContainerType::Command, code, tid, &payload);
-}
-
 pub struct PtpCamera<'a> {
     iface: u8,
     ep_in: u8,
@@ -911,48 +889,24 @@ impl<'a> PtpCamera<'a> {
 
         // timeout of 0 means unlimited timeout.
         let timeout = timeout.unwrap_or(Duration::new(0, 0));
-
-        // Send messages.
-        let mut cmd_message = vec![];
-        ptp_gen_cmd_message(&mut cmd_message, code, self.current_tid, params);
-
-        let timespec = time::get_time();
-        trace!("Write Cmnd [{}:{:09}] - 0x{:04x} ({}), tid:{}, params:{:?}",
-               timespec.sec,
-               timespec.nsec,
-               code,
-               StandardCommandCode::name(code).unwrap_or("unknown"),
-               self.current_tid,
-               params);
         
-        try!(self.handle.write_bulk(self.ep_out, &cmd_message, timeout));
+        let tid = self.current_tid;
+        self.current_tid += 1;
+
+        // Prepare payload of the request phase, containing the parameters
+        let mut request_payload = Vec::with_capacity(params.len() * 4);
+        for p in params {
+            request_payload.write_u32::<LittleEndian>(*p).ok();
+        }
+        
+        try!(self.write_txn_phase(PtpContainerType::Command, code, tid, &request_payload, timeout));
 
         if let Some(data) = data {
-            let mut data_message = vec![];
-            ptp_gen_message(&mut data_message,
-                            PtpContainerType::Data,
-                            code,
-                            self.current_tid,
-                            data);
-            let timespec = time::get_time();
-            trace!("Write Data [{}:{:09}] - 0x{:04x} ({}), tid:{}, len:{}",
-                   timespec.sec,
-                   timespec.nsec,
-                   code,
-                   StandardCommandCode::name(code).unwrap_or("unknown"),
-                   self.current_tid,
-                   data.len());
-            try!(self.handle.write_bulk(self.ep_out, &data_message, timeout));
+            try!(self.write_txn_phase(PtpContainerType::Data, code, tid, data, timeout));
         }
-
-        let tid = self.current_tid; // transaction id we're waiting for a response to
-        self.current_tid += 1;
 
         // request phase is followed by data phase (optional) and response phase.
         // read both, check the status on the response, and return the data payload, if any.
-        //
-        // NB: responses with mismatching transaction IDs are discarded - does this represent
-        //      an error, or should we do anything more helpful in this case?
         let mut data_phase_payload = vec![];
         loop {
             let (container, payload) = try!(self.read_txn_phase(timeout));
@@ -972,6 +926,20 @@ impl<'a> PtpCamera<'a> {
                 _ => {}
             }
         }
+    }
+    
+    fn write_txn_phase(&mut self, kind: PtpContainerType, code: CommandCode, tid: u32, payload: &[u8], timeout: Duration) -> Result<(), Error> {
+        trace!("Write {:?} - 0x{:04x} ({}), tid:{}", kind, code, StandardCommandCode::name(code).unwrap_or("unknown"), tid);
+        
+        let mut buf = Vec::with_capacity(payload.len() + PTP_CONTAINER_INFO_SIZE);
+        buf.write_u32::<LittleEndian>((payload.len() + PTP_CONTAINER_INFO_SIZE) as u32).ok();
+        buf.write_u16::<LittleEndian>(kind as u16).ok();
+        buf.write_u16::<LittleEndian>(code).ok();
+        buf.write_u32::<LittleEndian>(tid).ok();
+        buf.extend_from_slice(payload);
+        
+        try!(self.handle.write_bulk(self.ep_out, &buf, timeout));
+        Ok(())
     }
 
     // helper for command() above, retrieve container info and payload for the current phase


### PR DESCRIPTION
Linux fails with -ENOMEM on large transactions, and it's possible to avoid copying the whole payload.
